### PR TITLE
Fix Shebang Error in MacOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,137 +7,150 @@ const { prompt } = require("enquirer");
 
 const cwd = process.cwd();
 const renameFiles = {
-    _gitignore: ".gitignore",
+  _gitignore: ".gitignore",
 };
-const types = ['section', 'element']
+const types = ["section", "element"];
 
 async function init() {
-    let targetDir = argv._[0];
-    if (!targetDir) {
-        const { name } = await prompt({
-            type: "input",
-            name: "name",
-            message: `Project name:`,
-            initial: "weweb-custom",
-        });
-        targetDir = name;
+  let targetDir = argv._[0];
+  if (!targetDir) {
+    const { name } = await prompt({
+      type: "input",
+      name: "name",
+      message: `Project name:`,
+      initial: "weweb-custom",
+    });
+    targetDir = name;
+  }
+
+  const root = path.join(cwd, targetDir);
+  console.log(`\nScaffolding project in ${root}...`);
+
+  if (!fs.existsSync(root)) {
+    fs.mkdirSync(root, { recursive: true });
+  } else {
+    const existing = fs.readdirSync(root);
+    if (existing.length) {
+      /**
+       * @type {{ yes: boolean }}
+       */
+      const { yes } = await prompt({
+        type: "confirm",
+        name: "yes",
+        initial: "Y",
+        message:
+          `Target directory ${targetDir} is not empty.\n` +
+          `Remove existing files and continue?`,
+      });
+      if (yes) {
+        emptyDir(root);
+      } else {
+        return;
+      }
     }
+  }
 
-    const root = path.join(cwd, targetDir);
-    console.log(`\nScaffolding project in ${root}...`);
+  // determine type
+  let type = argv.t || argv.type;
+  let message = "Select a type:";
+  let isValidType = false;
 
-    if (!fs.existsSync(root)) {
-        fs.mkdirSync(root, { recursive: true });
+  // --type expects a value
+  if (typeof type === "string") {
+    isValidType = types.includes(type);
+    message = `${type} isn't a valid type. Please choose from below:`;
+  }
+
+  if (!type || !isValidType) {
+    /**
+     * @type {{ t: string }}
+     */
+    const { t } = await prompt({
+      type: "select",
+      name: "t",
+      message,
+      choices: types,
+    });
+    type = t;
+  }
+
+  let isReact = argv.r || argv.react;
+
+  const templateDir = path.join(
+    __dirname,
+    `template-${type}${isReact ? "-react" : ""}`
+  );
+
+  const write = (file, content) => {
+    const targetPath = renameFiles[file]
+      ? path.join(root, renameFiles[file])
+      : path.join(root, file);
+    if (content) {
+      fs.writeFileSync(targetPath, content);
     } else {
-        const existing = fs.readdirSync(root);
-        if (existing.length) {
-            /**
-             * @type {{ yes: boolean }}
-             */
-            const { yes } = await prompt({
-                type: "confirm",
-                name: "yes",
-                initial: "Y",
-                message: `Target directory ${targetDir} is not empty.\n` + `Remove existing files and continue?`,
-            });
-            if (yes) {
-                emptyDir(root);
-            } else {
-                return;
-            }
-        }
+      copy(path.join(templateDir, file), targetPath);
     }
+  };
 
-    // determine type
-    let type = argv.t || argv.type;
-    let message = "Select a type:";
-    let isValidType = false;
+  const files = fs.readdirSync(templateDir);
+  for (const file of files.filter((f) => f !== "package.json")) {
+    write(file);
+  }
 
-    // --type expects a value
-    if (typeof type === "string") {
-        isValidType = types.includes(type);
-        message = `${type} isn't a valid type. Please choose from below:`;
-    }
+  const pkg = require(path.join(templateDir, `package.json`));
+  pkg.name = path.basename(root);
+  write("package.json", JSON.stringify(pkg, null, 2));
 
-    if (!type || !isValidType) {
-        /**
-         * @type {{ t: string }}
-         */
-        const { t } = await prompt({
-            type: "select",
-            name: "t",
-            message,
-            choices: types,
-        });
-        type = t
-    }
+  const pkgManager = /yarn/.test(process.env.npm_execpath) ? "yarn" : "npm";
 
-    let isReact = argv.r || argv.react
-
-    const templateDir = path.join(__dirname, `template-${type}${isReact ? '-react' : ''}`);
-
-    const write = (file, content) => {
-        const targetPath = renameFiles[file] ? path.join(root, renameFiles[file]) : path.join(root, file);
-        if (content) {
-            fs.writeFileSync(targetPath, content);
-        } else {
-            copy(path.join(templateDir, file), targetPath);
-        }
-    };
-
-    const files = fs.readdirSync(templateDir);
-    for (const file of files.filter((f) => f !== "package.json")) {
-        write(file);
-    }
-
-    const pkg = require(path.join(templateDir, `package.json`));
-    pkg.name = path.basename(root);
-    write("package.json", JSON.stringify(pkg, null, 2));
-
-    const pkgManager = /yarn/.test(process.env.npm_execpath) ? "yarn" : "npm";
-
-    console.log(`\nDone. Now run:\n`);
-    if (root !== cwd) {
-        console.log(`  cd ${path.relative(cwd, root)}`);
-    }
-    console.log(`  ${pkgManager === "yarn" ? `yarn` : `npm install`}`);
-    console.log(`  ${pkgManager === "yarn" ? `yarn serve --port=[PORT]` : `npm run serve --port=[PORT]`}`);
-    console.log();
+  console.log(`\nDone. Now run:\n`);
+  if (root !== cwd) {
+    console.log(`  cd ${path.relative(cwd, root)}`);
+  }
+  console.log(`  ${pkgManager === "yarn" ? `yarn` : `npm install`}`);
+  console.log(
+    `  ${
+      pkgManager === "yarn"
+        ? `yarn serve --port=[PORT]`
+        : `npm run serve --port=[PORT]`
+    }`
+  );
+  console.log();
 }
 
 function copy(src, dest) {
-    const stat = fs.statSync(src);
-    if (stat.isDirectory()) {
-        copyDir(src, dest);
-    } else {
-        fs.copyFileSync(src, dest);
-    }
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    copyDir(src, dest);
+  } else {
+    fs.copyFileSync(src, dest);
+  }
 }
 
 function copyDir(srcDir, destDir) {
-    fs.mkdirSync(destDir, { recursive: true });
-    for (const file of fs.readdirSync(srcDir)) {
-        const srcFile = path.resolve(srcDir, file);
-        const destFile = path.resolve(destDir, file);
-        copy(srcFile, destFile);
-    }
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const file of fs.readdirSync(srcDir)) {
+    const srcFile = path.resolve(srcDir, file);
+    const destFile = path.resolve(destDir, file);
+    copy(srcFile, destFile);
+  }
 }
 
 function emptyDir(dir) {
-    if (!fs.existsSync(dir)) {
-        return;
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  for (const file of fs.readdirSync(dir)) {
+    const abs = path.resolve(dir, file);
+    if (fs.lstatSync(abs).isDirectory()) {
+      emptyDir(abs);
+      fs.rmdirSync(abs);
+    } else {
+      fs.unlinkSync(abs);
     }
-    for (const file of fs.readdirSync(dir)) {
-        const abs = path.resolve(dir, file);
-        if (fs.lstatSync(abs).isDirectory()) {
-            emptyDir(abs);
-            fs.rmdirSync(abs);
-        } else {
-            fs.unlinkSync(abs);
-        }
-    }
+  }
 }
 
 init().catch((e) => {
-    console.error(e);
+  console.error(e);
 });


### PR DESCRIPTION
This PR fixes issue #3  

As of MacOS 14.2.1, shebangs (the #! at the top of index.js) that contain a carriage return corrupt the line so it can't find the executable, generating the following error message:

```
❯ yarn create @weweb/component bibble
yarn create v1.22.19
warning package.json: No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "expo > babel-preset-expo > @babel/plugin-proposal-object-rest-spread@7.20.2" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "expo > babel-preset-expo > @babel/plugin-proposal-decorators > @babel/helper-create-class-features-plugin@7.20.5" has unmet peer dependency "@babel/core@^7.0.0".
warning "eas-cli > @expo/prebuild-config@5.0.3" has unmet peer dependency "expo-modules-autolinking@>=0.8.1".
warning "expo > babel-preset-expo > @babel/plugin-proposal-decorators@7.20.5" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "expo > babel-preset-expo > @babel/plugin-transform-react-jsx@7.19.0" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "expo > babel-preset-expo > metro-react-native-babel-preset@0.72.3" has unmet peer dependency "@babel/core@*".
warning "expo > babel-preset-expo > @babel/plugin-proposal-decorators > @babel/plugin-syntax-decorators@7.19.0" has unmet peer dependency "@babel/core@^7.0.0-0".
warning "expo > babel-preset-expo > @babel/plugin-transform-react-jsx > @babel/plugin-syntax-jsx@7.18.6" has unmet peer dependency "@babel/core@^7.0.0-0".
[4/4] 🔨  Building fresh packages...
success Installed "@weweb/create-component@1.0.13" with binaries:
      - create-component
env: node\r: No such file or directory
error Command failed.
Exit code: 127
Command: /Users/ray/.yarn/bin/create-component
Arguments: bibble
Directory: /Users/ray/Documents/vue/weweb
Output:

info Visit https://yarnpkg.com/en/docs/cli/create for documentation about this command.
```

I removed the CRLF (windows standard) newlines in index.js replaced them with LF (mac/linux standard) and it works great on a mac. Currently using my version of this via npm package @raydeck/create-weweb-component:

```
❯ npm init @raydeck/weweb-component bibble       
Need to install the following packages:
  @raydeck/create-weweb-component@1.0.13
Ok to proceed? (y) 

Scaffolding project in /Users/ray/Documents/vue/weweb/bibble...
✔ Select a type: · element

Done. Now run:

  cd bibble
  npm install
  npm run serve --port=[PORT]

```
WOuld love for others to get this better experience!
